### PR TITLE
dockerfile: update alpine & go, run rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM golang:1.19-alpine
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /go/src/genesis
 RUN mkdir -p /app
-
 
 COPY . .
 RUN go mod download
 RUN go build -o /app/genesis ./cmd
 
-FROM golang:alpine
-COPY --from=0 /app/genesis /app/genesis
+FROM alpine:3.20
+COPY --from=builder /app/genesis /app/genesis
 
+USER nobody
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+	CMD wget -q --spider "http://localhost:8080/metrics"
 
 WORKDIR /app
 ENTRYPOINT ["./genesis"]
-


### PR DESCRIPTION
Update Go to 1.22 since 1.19 is EOL, and run on basic Alpine image (no need for golang to execute).

Run the service as "nobody" rather than root for security.

Also, added health check.